### PR TITLE
Added mongodb env variable to match the default name for Heroku addons

### DIFF
--- a/export-import-tools/import-mongodb-brain.coffee
+++ b/export-import-tools/import-mongodb-brain.coffee
@@ -5,6 +5,7 @@ async       = require 'async'
 MongoClient = require('mongodb').MongoClient
 
 mongoUrl = process.env.MONGODB_URL or
+           process.env.MONGODB_URI or
            process.env.MONGOLAB_URI or
            process.env.MONGOHQ_URL or
            'mongodb://localhost/hubot-brain'

--- a/scripts/hubot-mongodb-brain.coffee
+++ b/scripts/hubot-mongodb-brain.coffee
@@ -21,6 +21,7 @@ deepClone = (obj) -> JSON.parse JSON.stringify obj
 
 module.exports = (robot) ->
   mongoUrl = process.env.MONGODB_URL or
+             process.env.MONGODB_URI or
              process.env.MONGOLAB_URI or
              process.env.MONGOHQ_URL or
              'mongodb://localhost/hubot-brain'


### PR DESCRIPTION
https://devcenter.heroku.com/articles/mongolab#adding-mlab-as-a-heroku-add-on

Heroku mLab addon uses `MONGODB_URI` environment variable as a default.
