### PR TITLE
Use a global variable for 'db' to avoid trace

### DIFF
--- a/scripts/hubot-mongodb-brain.coffee
+++ b/scripts/hubot-mongodb-brain.coffee
@@ -25,11 +25,11 @@ module.exports = (robot) ->
              process.env.MONGOHQ_URL or
              'mongodb://localhost/hubot-brain'
 
-  var db = null // global var for db connection
+  var db = null
 
   MongoClient.connect mongoUrl, (err, connection) ->
     throw err if err
-    db = connection // assign db global var if no errors
+    db = connection
 
     robot.brain.on 'close', ->
       db.close()

--- a/scripts/hubot-mongodb-brain.coffee
+++ b/scripts/hubot-mongodb-brain.coffee
@@ -25,8 +25,11 @@ module.exports = (robot) ->
              process.env.MONGOHQ_URL or
              'mongodb://localhost/hubot-brain'
 
-  MongoClient.connect mongoUrl, (err, db) ->
+  var db = null // global var for db connection
+
+  MongoClient.connect mongoUrl, (err, connection) ->
     throw err if err
+    db = connection // assign db global var if no errors
 
     robot.brain.on 'close', ->
       db.close()


### PR DESCRIPTION
I receive this error from the latest hubot-mongodb-brain:

```
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Logging In
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Successfully Logged In
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO rid:  []
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO All rooms joined.
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Preparing Meteor Subscriptions..
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Subscribing to Room: __my_messages__
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Successfully subscribed to messages
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] INFO Setting up reactive message list...
[Thu Feb 01 2018 13:46:00 GMT+0000 (UTC)] WARNING Loading scripts from hubot-scripts.json is deprecated and will be removed in 3.0 (https://github.com/github/hubot-scripts/issues/1113) in favor of packages for each script.

Your hubot-scripts.json is empty, so you just need to remove it.
[Thu Feb 01 2018 13:46:01 GMT+0000 (UTC)] INFO MongoDB connected
[Thu Feb 01 2018 13:46:01 GMT+0000 (UTC)] ERROR TypeError: db.createCollection is not a function
    at /home/hubot/node_modules/hubot-mongodb-brain/scripts/hubot-mongodb-brain.coffee:40:8
    at /home/hubot/node_modules/hubot-mongodb-brain/node_modules/mongodb/lib/utils.js:404:72
    at /home/hubot/node_modules/hubot-mongodb-brain/node_modules/mongodb/lib/mongo_client.js:271:5
    at connectCallback (/home/hubot/node_modules/hubot-mongodb-brain/node_modules/mongodb/lib/mongo_client.js:950:5)
    at /home/hubot/node_modules/hubot-mongodb-brain/node_modules/mongodb/lib/mongo_client.js:811:11
    at nextTickCallbackWith0Args (node.js:489:9)
    at process._tickCallback (node.js:418:13)
```

After some investigation I found several articles explaining that the fix is to move 'db' to be a global variable. This global variable is set to null until the connection succeeds.

Reference: https://www.codesd.com/item/the-best-way-to-connect-to-mongodb-using-node.html